### PR TITLE
Making the Data dictionary private

### DIFF
--- a/src/Flex/Configuration/FlexConfiguration.cs
+++ b/src/Flex/Configuration/FlexConfiguration.cs
@@ -58,9 +58,9 @@ namespace Flex.Configuration
 
             foreach (var entry in dataDict)
             {
-                if (!container.Data.ContainsKey(entry.Key))
+                if (!container.TryGetValue(entry.Key, out string _))
                 {
-                    container.Data.Add(entry.Key, entry.Value.ToString());
+                    container.Set(entry.Key, entry.Value.ToString());
                 }
             }
 
@@ -94,9 +94,9 @@ namespace Flex.Configuration
 
             foreach (var entry in dict)
             {
-                if (!container.Data.ContainsKey(entry.Key))
+                if (!container.TryGetValue(entry.Key, out string _))
                 {
-                    container.Data.Add(entry.Key, entry.Value);
+                    container.Set(entry.Key, entry.Value);
                 }
             }
 

--- a/src/Flex/FlexContainer.cs
+++ b/src/Flex/FlexContainer.cs
@@ -4,7 +4,7 @@ namespace Flex
 {
     public class FlexContainer : IFlexContainer
     {
-        internal Dictionary<string, string> Data { get; }
+        private Dictionary<string, string> Data { get; }
         public FlexContainer(Dictionary<string, string> data)
         {
             Data = data;

--- a/src/Flex/FlexContainer.cs
+++ b/src/Flex/FlexContainer.cs
@@ -20,6 +20,11 @@ namespace Flex
             return Data[key];
         }
 
+        internal void Set(string key, string value)
+        {
+            Data.Add(key, value);
+        }
+
         public bool TryGetValue(string key, out string value)
         {
             if (Data.TryGetValue(key, out value))


### PR DESCRIPTION
Access to the dictionary should be controlled by the methods exposed by the container. Made the Data dictionary private to push developers to use the methods exposed.

Added an internal Set method not exposed in the interface to allow us to still add items to the dictionary while configuring the container.

Closes #19 